### PR TITLE
PIE-461 Fix namespace in profile navigation

### DIFF
--- a/classes/ProfilePage.php
+++ b/classes/ProfilePage.php
@@ -978,7 +978,7 @@ __NOINDEX__
 				[[User:' . $userName . '|' . wfMessage( 'userprofile-userprofilenavigation-link-about' )->plain() . ']]
 			</li>
 			<li class="user-profile-navigation__link">
-				[[UserTalk:' . $userName . '|' . wfMessage( 'userprofile-userprofilenavigation-link-user-talk' )->plain() . ']]
+				[[User_talk:' . $userName . '|' . wfMessage( 'userprofile-userprofilenavigation-link-user-talk' )->plain() . ']]
 			</li>
 			<li class="user-profile-navigation__link">
 				[[Special:Contributions/' . $userName . '|' . wfMessage( 'userprofile-userprofilenavigation-link-contributions' )->plain() . ']]


### PR DESCRIPTION
English namespaces will redirect to their i18n equivalents, but the namespace has to be spelled correctly first.