### PR TITLE
MAIN-24417 Fix SVG icon that renders too large

### DIFF
--- a/classes/ProfilePage.php
+++ b/classes/ProfilePage.php
@@ -406,7 +406,8 @@ class ProfilePage extends Article {
 		// Check the rights of the person viewing this page.
 		$cGroups = $wgUser->changeableGroups();
 		if (!empty($cGroups['add']) || !empty($cGroups['remove'])) {
-			$html .= "<li class=\"edit\">" . Linker::linkKnown(Title::newFromText('Special:UserRights/' . $this->user->getName()), self::PENCIL_ICON_SVG) . "</li>";
+			$link = Linker::linkKnown(Title::newFromText('Special:UserRights/' . $this->user->getName()), self::PENCIL_ICON_SVG, [ 'class' => 'is-icon' ] );
+			$html .= "<li class=\"edit\">" . $link . "</li>";
 		}
 		$html .= '</ul>';
 

--- a/css/curseprofile.css
+++ b/css/curseprofile.css
@@ -437,7 +437,7 @@ ul.friends {
 	}
 }
 
-.curseprofile a.is-icon {
+.curseprofile a.is-icon svg {
 	height: 18px;
 	width: 18px;
 }


### PR DESCRIPTION
Adds CSS class to group tags "edit" link and sets dimensions on SVG rather than the anchor tag.