### PR TITLE
MAIN-24435 Fix display of comment replies on Curse profile

### DIFF
--- a/css/comments.css
+++ b/css/comments.css
@@ -7,10 +7,7 @@
 	.commentdisplay .right {
 		float: right;
 	}
-		.commentdisplay .right a {
-			margin-left: 3px;
-		}
-		.commentdisplay .right a.purge {
+		.commentdisplay .right .icon {
 			margin-left: 5px;
 		}
 

--- a/css/curseprofile.css
+++ b/css/curseprofile.css
@@ -598,17 +598,17 @@ body.skin-fandomdesktop .curseprofile .comments .avatar img {
 	width: 42px;
 }
 
-body.skin-fandomdesktop .curseprofile .commentdisplay {
+body.skin-fandomdesktop .curseprofile .commentdisplay.add-comment {
 	align-items: flex-start;
 	display: flex;
 }
 
-body.skin-fandomdesktop .curseprofile .commentdisplay .entryform {
+body.skin-fandomdesktop .curseprofile .commentdisplay.add-comment .entryform {
 	flex-basis: 100%;
 	margin: 0 0 0 12px;
 }
 
-body.skin-fandomdesktop .curseprofile .commentdisplay .entryform form {
+body.skin-fandomdesktop .curseprofile .commentdisplay.add-comment .entryform form {
 	text-align: right;
 }
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/MAIN-24435

 * Apply `display: flex` only to the add-comment entry form, not all comments
 * Tweak spacing around comment moderation icons