### PR TITLE
MAIN-24481 Fix profile nav links

### DIFF
--- a/classes/ProfilePage.php
+++ b/classes/ProfilePage.php
@@ -970,8 +970,7 @@ __NOINDEX__
 
 		$userName = $this->user->getName();
 		$userPageUrl = $this->user->getUserPage()->getFullURL();
-		$queryParam = $this->user->getOption( 'profile-pref' ) ? '|profile=no' : '';
-echo 'TEST queryParam = '.$queryParam;
+		$queryParam = $this->user->getIntOption( 'profile-pref' ) ? '|profile=no' : '';
 
 		return '<ul class="user-profile-navigation">
 			<li class="user-profile-navigation__link is-active">

--- a/classes/ProfilePage.php
+++ b/classes/ProfilePage.php
@@ -971,6 +971,7 @@ __NOINDEX__
 		$userName = $this->user->getName();
 		$userPageUrl = $this->user->getUserPage()->getFullURL();
 		$queryParam = $this->user->getOption( 'profile-pref' ) ? '|profile=no' : '';
+echo 'TEST queryParam = '.$queryParam;
 
 		return '<ul class="user-profile-navigation">
 			<li class="user-profile-navigation__link is-active">


### PR DESCRIPTION
`getIntOption` is needed to properly check the preference setting for the profile page.