### PR TITLE
Ensure onHtmlPageLinkRendererEnd() always operates on a Title

### DIFF
--- a/classes/Hooks.php
+++ b/classes/Hooks.php
@@ -207,6 +207,7 @@ class Hooks {
 		&$attribs,
 		&$ret
 	) {
+		$target = Title::newFromLinkTarget($target);
 		// Only process user namespace links
 		if (!in_array($target->getNamespace(), [NS_USER, NS_USER_PROFILE]) || $target->isSubpage()) {
 			return true;


### PR DESCRIPTION
onHtmlPageLinkRendererEnd() assumes it's always passed a Title, but it
may in some cases receive a TitleValue instead, which lacks an
isSubpage() method. This completely breaks Special:LinkSearch on
historically Gamepedia wikis, probably other things as well. Fix it by
making sure that we always operate on a Title object.