### PR TITLE
DPAD-516 Fix fatal error when user has no friends

### DIFF
--- a/templates/TemplateManageFriends.php
+++ b/templates/TemplateManageFriends.php
@@ -58,7 +58,10 @@ class TemplateManageFriends {
 		$sent = $friendTypes['outgoing_requests'];
 
 		$this->HTML = '';
-		$pagination = HydraCore::generatePaginationHtml(SpecialPage::getTitleFor('ManageFriends'), count($friends), $itemsPerPage, $start);
+		$pagination = count($friends) ? HydraCore::generatePaginationHtml(
+			SpecialPage::getTitleFor('ManageFriends'),
+			count($friends), $itemsPerPage, $start
+		) : '';
 
 		if (count($received)) {
 			$this->HTML .= '<h2>' . wfMessage('pendingrequests') . '</h2>';


### PR DESCRIPTION
It's a double whammy: not only does the user have no friends but a fatal error prevents the page from loading so they can't even send a friend invite.

(Pagination can be an empty string when the friend count is 0. This avoids the error in `HydraCore`.)