### PR TITLE
MAIN-27737 | Remove group permissions settings

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -22,12 +22,6 @@
 		"profile-purgecomments",
 		"profile-stats"
 	],
-	"GroupPermissions": {
-		"sysop": {
-			"profile-moderate": true,
-			"profile-purgecomments": true
-		}
-	},
 	"GrantPermissions": {
 		"curseprofile": {
 			"profile-moderate": true,


### PR DESCRIPTION
This removes the ability to edit and delete comments from sysop.