### PR TITLE
CATS-3187 | Split out profile-comments-moderate permission

### DIFF
--- a/classes/Comment.php
+++ b/classes/Comment.php
@@ -251,7 +251,7 @@ class Comment {
 	 */
 	public function canView(User $user) {
 		// Early check for admin status.
-		if ($user->isAllowed('profile-moderate')) {
+		if ($user->isAllowed('profile-comments-moderate')) {
 			return true;
 		}
 
@@ -334,7 +334,7 @@ class Comment {
 		return $this->getType() !== self::DELETED_MESSAGE && !$actor->getBlock() &&
 			($this->getBoardOwnerUserId() === $actor->getId()
 				|| ($this->getActorUserId() === $actor->getId())
-				|| $actor->isAllowed('profile-moderate'));
+				|| $actor->isAllowed('profile-comments-moderate'));
 	}
 
 	/**
@@ -348,7 +348,7 @@ class Comment {
 		// comment must be deleted, user has mod permissions or was the original author and deleter
 		return $this->getType() === self::DELETED_MESSAGE &&
 			(
-				$actor->isAllowed('profile-moderate')
+				$actor->isAllowed('profile-comments-moderate')
 				|| $this->getBoardOwnerUserId() === $actor->getId()
 				&& $this->getAdminActedUserId() === $actor->getId()
 			);

--- a/classes/CommentApi.php
+++ b/classes/CommentApi.php
@@ -160,7 +160,7 @@ class CommentApi extends HydraApiBase {
 			'resolveReport' => [
 				'tokenRequired' => true,
 				'postRequired' => true,
-				'permissionRequired' => 'profile-moderate',
+				'permissionRequired' => 'profile-comments-moderate',
 				'params' => [
 					'reportKey' => [
 						ParamValidator::PARAM_TYPE => 'string',

--- a/classes/CommentBoard.php
+++ b/classes/CommentBoard.php
@@ -156,7 +156,7 @@ class CommentBoard {
 	 * @return string A single SQL condition entirely enclosed in parenthesis.
 	 */
 	public static function visibleClause(User $actor) {
-		if ($actor->isAllowed('profile-moderate')) {
+		if ($actor->isAllowed('profile-comments-moderate')) {
 			// admins see everything
 			$sql = '1=1';
 		} else {

--- a/extension.json
+++ b/extension.json
@@ -19,18 +19,21 @@
 	},
 	"AvailableRights": [
 		"profile-moderate",
+		"profile-comments-moderate",
 		"profile-purgecomments",
 		"profile-stats"
 	],
 	"GroupPermissions": {
 		"sysop": {
 			"profile-moderate": true,
+			"profile-comments-moderate": true,
 			"profile-purgecomments": true
 		}
 	},
 	"GrantPermissions": {
 		"curseprofile": {
 			"profile-moderate": true,
+			"profile-comments-moderate": true,
 			"profile-purgecomments": true
 		}
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -261,6 +261,7 @@
 	"apihelp-profile-summary": "Allows basic profile data actions to be modified.",
 	"apihelp-friend-summary": "Allows friending actions to be taken.",
 	"right-profile-moderate": "Moderate user profiles",
+	"right-profile-comments-moderate": "Moderate comments on user profiles",
 	"right-profile-purgecomments": "Purge comments on user profiles",
 	"right-profile-stats": "View profile statistics",
 	"grant-curseprofile": "Moderate user profiles and comments",

--- a/specials/comments/SpecialCommentModeration.php
+++ b/specials/comments/SpecialCommentModeration.php
@@ -21,7 +21,7 @@ class SpecialCommentModeration extends SpecialPage {
 	private $sortStyle;
 
 	public function __construct() {
-		parent::__construct('CommentModeration', 'profile-moderate');
+		parent::__construct('CommentModeration', 'profile-comments-moderate');
 	}
 
 	/**


### PR DESCRIPTION
Profile permissions should be more granular so as to allow a given user
group to moderate comments without gaining the ability to edit user
profile contents. Do this by introducing a new
'profile-comments-moderate' permission that shall henceforth be used for
authorizing comments-related moderation actions, and using the old
'profile-moderate' permission only for authorizing profile content edits
to other users' profiles.

By default, both permissions will be assigned to the 'sysop' group.
Fandom-specific permission assignments will be made in local
configuration as needed.