### PR TITLE
Fix observed error in API edits

### DIFF
--- a/src/Classes/Hooks.php
+++ b/src/Classes/Hooks.php
@@ -306,7 +306,7 @@ class Hooks implements
 		$skinTitle = $sktemplate->getContext()->getTitle();
 		$skinNamespace = $sktemplate->getContext()->getTitle()->getNamespace();
 		// Only modify the navbar if we are on a user, user talk, or profile page
-		if ( self::$profilePage !== false && in_array( $skinNamespace, [ NS_USER, NS_USER_TALK, NS_USER_PROFILE ] ) ) {
+		if ( self::$profilePage !== null && in_array( $skinNamespace, [ NS_USER, NS_USER_TALK, NS_USER_PROFILE ] ) ) {
 			self::$profilePage->customizeNavBar( $links, $skinTitle );
 		}
 	}


### PR DESCRIPTION
`$profilePage` may be null or a `ProfilePage` instance, but it can never be false. This causes an error on some API edits where we attempt to invoke a method on a null value.