### PR TITLE
Add proper robots policy to the UserProfile pages

### DIFF
--- a/src/Classes/NoProfilePage.php
+++ b/src/Classes/NoProfilePage.php
@@ -22,6 +22,7 @@ class NoProfilePage extends Article {
 	 */
 	public function view() {
 		$output = $this->getContext()->getOutput();
+		$output->setRobotPolicy( 'noindex,nofollow' );
 		$output->setPageTitle( $this->getTitle()->getPrefixedText() );
 		$output->addHTML( $this->getOutputHtml() );
 	}


### PR DESCRIPTION
## Description
Currently, we are correctly adding those meta tags to the UserProfiles for the users that are found. Unfortunately, we render different page if the user doesn't exists and which pages are currently indexed. This is not ideal from SEO perspective as those pages don't bring any value and also uses a lot of crawling capacity for the Google, Bing indexers.

## Who might be interested?
@Wikia/platform-team 