### PR TITLE
LYLTY-754 | Add Phalanx checks and ratelimiting to CurseProfile

### DIFF
--- a/src/Classes/CommentBoard.php
+++ b/src/Classes/CommentBoard.php
@@ -200,6 +200,17 @@ class CommentBoard {
 			$parentCommenter = $parentComment->getActorUser();
 		}
 
+		// Apply rate limiting (MAIN-29037).
+		if ( $fromUser->pingLimiter( 'curseprofile-comment' ) ) {
+			return false;
+		}
+
+		// Validate comment content against Phalanx (LYLTY-754).
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		if ( !$hookContainer->run( 'SpamFilterCheck', [ $fromUser, $commentText ] ) ) {
+			return false;
+		}
+
 		$comment->setMessage( $commentText );
 		$comment->setActorUser( $fromUser );
 		$comment->markAsPublic();

--- a/src/Classes/ProfileData.php
+++ b/src/Classes/ProfileData.php
@@ -261,6 +261,13 @@ class ProfileData {
 	 * @return void
 	 */
 	public function setFields( array $fields, User $performer ): void {
+		$fieldValues = implode( "\n", $fields );
+		// Validate profile content against Phalanx (LYLTY-754).
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		if ( !$hookContainer->run( 'SpamFilterCheck', [ $performer, $fieldValues ] ) ) {
+			throw new MWException( 'Invalid profile field.' );
+		}
+
 		foreach ( $fields as $field => $text ) {
 			$field = 'profile-' . $field;
 			if ( !in_array( $field, self::getValidEditFields() ) ) {


### PR DESCRIPTION
Neither CurseProfile comments nor profile fields were integrated with Phalanx, nor did commenting have a ratelimiter. Implement both.