### PR TITLE
UGC-5176 Purge comments on QuickTools action

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -83,7 +83,8 @@
 		"CurseProfileMagic": "/CurseProfile.i18n.magic.php"
 	},
 	"JobClasses": {
-		"CurseProfile\\ResolveComment": "CurseProfile\\Classes\\Jobs\\ResolveComment::newInstance"
+		"CurseProfile\\ResolveComment": "CurseProfile\\Classes\\Jobs\\ResolveComment::newInstance",
+		"CurseProfile\\PurgeComments": "CurseProfile\\Classes\\Jobs\\PurgeCommentsJob::newInstance"
 	},
 	"namespaces": [
 		{
@@ -314,6 +315,14 @@
 		},
 		"CurseProfileRegistrationHandler": {
 			"class": "CurseProfile\\OnExtensionRegistration"
+		},
+		"QuickToolsHookHandler": {
+			"class": "CurseProfile\\Classes\\QuickToolsHookHandler",
+			"services": [
+				"JobQueueGroup",
+				"DBLoadBalancer",
+				"UserFactory"
+			]
 		}
 	},
 	"Hooks": {
@@ -333,7 +342,8 @@
 		"UserGetDefaultOptions": "CurseProfileHookHandler",
 		"NamespaceIsMovable": "CurseProfileHookHandler",
 		"FandomUserSaveOptions": "CurseProfileHookHandler",
-		"getUserPermissionsErrors": "CurseProfileHookHandler"
+		"getUserPermissionsErrors": "CurseProfileHookHandler",
+		"QuickToolsRevertOrDelete": "QuickToolsHookHandler"
 	},
 	"APIModules": {
 		"profile": {

--- a/src/Classes/Jobs/PurgeCommentsJob.php
+++ b/src/Classes/Jobs/PurgeCommentsJob.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace CurseProfile\Classes\Jobs;
+
+use CurseProfile\Classes\Comment;
+use CurseProfile\Classes\CommentBoard;
+use Fandom\Includes\Logging\Loggable;
+use Fandom\Includes\Rabbit\JobConfigurator;
+use Fandom\Includes\Rabbit\JobParams;
+use IDatabase;
+use Job;
+use JobSpecification;
+use MediaWiki\Config\ServiceOptions;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\User\UserFactory;
+use Wikimedia\Rdbms\ILBFactory;
+use Wikimedia\Rdbms\IResultWrapper;
+
+/**
+ * Job that mass purges comments made by a user
+ */
+class PurgeCommentsJob extends Job {
+	use Loggable;
+
+	private const CONSTRUCTOR_OPTIONS = [ 'FandomBotUserName' ];
+	private const COMMAND = "CurseProfile\\PurgeComments";
+	private const JOB_OWNER = JobConfigurator::UGC_TEAM_LABEL;
+	private const LIMIT = 100;
+	private int $targetUserId;
+	private string $summary;
+	private string $time;
+
+	public function __construct(
+		array $params,
+		private ILBFactory $lbFactory,
+		private UserFactory $userFactory,
+		private ServiceOptions $serviceOptions
+	) {
+		$this->serviceOptions->assertRequiredOptions( self::CONSTRUCTOR_OPTIONS );
+		$this->targetUserId = $params['targetUserId'];
+		$this->summary = $params['summary'];
+		$this->time = $params['time'];
+
+		parent::__construct( self::COMMAND, $params );
+	}
+
+	public static function newSpecification(
+		int $targetUserId,
+		string $summary,
+		string $time,
+	): JobSpecification {
+		return new JobSpecification(
+			self::COMMAND,
+			[
+				JobParams::JOB_OWNER => self::JOB_OWNER,
+				'targetUserId' => $targetUserId,
+				'summary' => $summary,
+				'time' => $time,
+			]
+		);
+	}
+
+	public static function newInstance( ?Title $title, $params ): Job {
+		$services = MediaWikiServices::getInstance();
+
+		return new PurgeCommentsJob(
+			$params,
+			$services->getDBLoadBalancerFactory(),
+			$services->getUserFactory(),
+			new ServiceOptions(
+				self::CONSTRUCTOR_OPTIONS,
+				$services->getMainConfig()
+			),
+		);
+	}
+
+	public function run(): void {
+		$botUser = $this->userFactory->newFromName( $this->serviceOptions->get( 'FandomBotUserName' ) );
+		$lastOffset = 0;
+		$ticket = $this->lbFactory->getEmptyTransactionTicket( __METHOD__ );
+		$lb = $this->lbFactory->getMainLB();
+		$connection = $lb->getConnection( DB_PRIMARY );
+		$commentsFromDB = $this->getCommentsFromTimestamp( $connection, $this->targetUserId, $this->time, $lastOffset );
+		while ( $commentsFromDB->numRows() ) {
+			foreach ( $commentsFromDB as $commentRow ) {
+				try {
+					$lastOffset = $commentRow->ub_id;
+					$comment = new Comment( (array)$commentRow );
+					CommentBoard::purgeComment( $comment, $botUser, $this->summary );
+				} catch ( \MWException $e ) {
+					$this->error( "Failed to purge comment", [ 'exception' => $e ] );
+				}
+			}
+			$this->lbFactory->commitAndWaitForReplication( __METHOD__, $ticket );
+			$commentsFromDB =
+				$this->getCommentsFromTimestamp( $connection, $this->targetUserId, $this->time, $lastOffset );
+		}
+	}
+
+	private function getCommentsFromTimestamp(
+		IDatabase $connection,
+		int $targetUserId,
+		string $time,
+		int $offsetId
+	): IResultWrapper {
+		return $connection
+			->newSelectQueryBuilder()
+			->select( '*' )
+			->from( 'user_board' )
+			->where( [
+				"ub_id > $offsetId",
+				'ub_user_id_from' => $targetUserId,
+				"ub_date > $time",
+			] )
+			->limit( self::LIMIT )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+	}
+}

--- a/src/Classes/QuickToolsHookHandler.php
+++ b/src/Classes/QuickToolsHookHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace CurseProfile\Classes;
+
+use CurseProfile\Classes\Jobs\PurgeCommentsJob;
+use Fandom\QuickTools\Hook\QuickToolsRevertOrDelete;
+use JobQueueGroup;
+use MediaWiki\User\UserFactory;
+use Wikimedia\Rdbms\ILoadBalancer;
+
+class QuickToolsHookHandler implements QuickToolsRevertOrDelete {
+
+	public function __construct(
+		private JobQueueGroup $jobQueueGroup,
+		private ILoadBalancer $lb,
+		private UserFactory $userFactory,
+	) {
+	}
+
+	public function onQuickToolsRevertOrDelete(
+		string $targetUsername,
+		string $time,
+		string $summary,
+		bool $doRollback,
+		bool $doDelete,
+		bool &$alteredByHook,
+	): void {
+		if ( !$doDelete ) {
+			return;
+		}
+
+		$targetUser = $this->userFactory->newFromName( $targetUsername );
+		if ( !$targetUser && !$targetUser->isRegistered() ) {
+			return;
+		}
+
+		if ( !$this->willRemove( $targetUser->getId(), $time ) ) {
+			return;
+		}
+
+		$this->jobQueueGroup->lazyPush(
+			PurgeCommentsJob::newSpecification( $targetUser->getId(), $summary, $time )
+		);
+		$alteredByHook = true;
+	}
+
+	private function willRemove( int $targetUserId, string $time ): bool {
+		$db = $this->lb->getConnection( DB_REPLICA );
+		$timestamp = $db->timestamp( $time );
+
+		return boolval(
+			$this->lb->getConnection( DB_REPLICA )
+				->newSelectQueryBuilder()
+				->select( '*' )
+				->from( 'user_board' )
+				->where( [
+					'ub_user_id_from' => $targetUserId,
+					"ub_date > $timestamp",
+				] )
+				->limit( 1 )
+				->caller( __METHOD__ )
+				->fetchRowCount()
+		);
+	}
+
+}


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/UGC-5176
* https://github.com/Wikia/unified-platform/pull/16602

## Description
In https://github.com/Wikia/unified-platform/pull/16602 A hook interface was added that allows plugging in additional logic that will be performed on a QuickTools revert / delete action.

To mass delete comments we introduced a job that does it asynchronously, as their volume can be potentially quite large, and with every comment deletion (purge) some extra logic has to be performed, potentially involving a couple DB calls.

To let the hook caller know whether any action was performed, before a job is executed, a quick lookup is performed to predetermine whether there's anything to remove.